### PR TITLE
fix: Bash 3.2 / macOS compatibility for installer and scripts

### DIFF
--- a/CHANGES-BASH32-COMPAT.md
+++ b/CHANGES-BASH32-COMPAT.md
@@ -1,0 +1,105 @@
+# Summary of Changes: Bash 3.2 / macOS Compatibility
+
+This document summarizes the edits made so that the claw-spark installer and scripts run on **macOS with the default Bash 3.2**, and remain **portable across Bash 3.2, 4.x, and 5.x**.
+
+---
+
+## 1. Detailed Summary of Changes
+
+### 1.1 `lib/common.sh`
+
+| Location | Before | After |
+|----------|--------|--------|
+| **New helper** (after line ~28) | — | Added `to_lower() { echo "$1" \| tr '[:upper:]' '[:lower:]'; }` |
+| **`prompt_choice()`** (lines 70–109) | Used `local -n _options=$2` and `${_options[@]}`, `${_options[$i]}` | Uses `options_name="$2"` and `eval` for indirect array access: `eval "count=\${#${options_name}[@]}"`, `eval "opt=\${${options_name}[$i]}"`, etc. |
+| **`prompt_yn()`** (answer normalization) | `answer="${answer,,}"` | `answer=$(to_lower "${answer}")` |
+
+**Purpose:**  
+- `local -n` (nameref) is Bash 4.3+. Replacing it with “array name + eval” allows the same behavior on Bash 3.2.  
+- `${var,,}` (lowercase) is Bash 4+. Replacing with `tr` keeps behavior and works on all Bash versions.
+
+### 1.2 `lib/select-model.sh`
+
+| Location | Before | After |
+|----------|--------|--------|
+| **`_present_model_choices()`** (lines 188–230) | `local -n _ids=$1`, `local -n _names=$2`, `local -n _labels=$3` and direct `${_ids[$i]}`, `${_labels[$i]}`, etc. | Takes array **names** as `_ids_name`, `_names_name`, `_labels_name` and uses `eval` for reads/writes: `eval "SELECTED_MODEL_ID=\${${_ids_name}[$i]}"`, `eval "label_val=\${${_labels_name}[$i]}"`, and similar. |
+
+**Purpose:** Same as above: avoid namerefs so the script runs on Bash 3.2 while keeping behavior identical on 4.x/5.x.
+
+### 1.3 `install.sh`
+
+| Location | Before | After |
+|----------|--------|--------|
+| **Step 5 – messaging** (line ~216) | `FLAG_MESSAGING="${FLAG_MESSAGING,,}"` | `FLAG_MESSAGING=$(to_lower "${FLAG_MESSAGING}")` |
+
+**Purpose:** Lowercase the messaging choice in a way that works on Bash 3.2 (macOS default).
+
+### 1.4 `lib/setup-messaging.sh`
+
+| Location | Before | After |
+|----------|--------|--------|
+| **Messaging choice** (line ~18) | `messaging_choice="${messaging_choice,,}"` | `messaging_choice=$(to_lower "${messaging_choice}")` |
+
+**Purpose:** Same as above; `to_lower` is available because this script is sourced after `common.sh`.
+
+### 1.5 `lib/setup-voice.sh`
+
+| Location | Before | After |
+|----------|--------|--------|
+| **Messaging variable** (line ~49) | `messaging="${messaging,,}"` | `messaging=$(to_lower "${messaging}")` |
+
+**Purpose:** Same lowercase normalization without Bash 4+ syntax.
+
+### 1.6 `uninstall.sh`
+
+| Location | Before | After |
+|----------|--------|--------|
+| **remove_models** (line ~83) | `remove_models="${remove_models,,}"` | `remove_models=$(echo "${remove_models}" \| tr '[:upper:]' '[:lower:]')` |
+| **revert_fw** (line ~139) | `revert_fw="${revert_fw,,}"` | `revert_fw=$(echo "${revert_fw}" \| tr '[:upper:]' '[:lower:]')` |
+
+**Purpose:** `uninstall.sh` does not source `common.sh`, so it uses inline `tr` instead of `to_lower` to achieve the same lowercase behavior on Bash 3.2.
+
+---
+
+## 2. Purpose Behind the Changes
+
+- **Run on macOS out of the box**  
+  macOS ships with Bash 3.2 (`/bin/bash`). The original code used:
+  - **Namerefs** (`local -n`) → Bash 4.3+
+  - **Parameter expansion for case** (`${var,,}`) → Bash 4+
+
+  So the installer failed on macOS with “invalid option” and “bad substitution”. The changes remove these features and use constructs that work in Bash 3.2.
+
+- **Keep behavior the same**  
+  - Menu behavior and default selection are unchanged.  
+  - All case-insensitive comparisons still use lowercased values.
+
+- **No new dependencies**  
+  Only `eval`, `tr`, and standard Bash 3.2 features are used.
+
+---
+
+## 3. Portability Across Bash Versions
+
+**Yes. The changes are portable across Bash 3.2, 4.x, and 5.x.**
+
+| Construct used | Bash 3.2 | Bash 4.x / 5.x |
+|----------------|----------|-----------------|
+| `eval` for indirect array access | ✅ | ✅ |
+| `tr '[:upper:]' '[:lower:]'` | ✅ (POSIX) | ✅ |
+| `echo "$var" \| tr ...` | ✅ | ✅ |
+| No `local -n` | ✅ (not needed) | ✅ (still valid) |
+| No `${var,,}` | ✅ (not used) | ✅ (still valid elsewhere if needed) |
+
+So:
+
+- **Bash 3.2 (e.g. macOS):** Scripts run without “invalid option” or “bad substitution”.
+- **Bash 4.x / 5.x (e.g. Linux, Homebrew bash):** Same behavior; no reliance on 4.3+ namerefs or 4+ case conversion in the modified code.
+
+The chosen patterns are standard and safe across these versions.
+
+---
+
+**Files modified:**  
+`install.sh`, `lib/common.sh`, `lib/select-model.sh`, `lib/setup-messaging.sh`, `lib/setup-voice.sh`, `uninstall.sh`  
+**File added:** `CHANGES-BASH32-COMPAT.md` (this summary).

--- a/install.sh
+++ b/install.sh
@@ -213,7 +213,7 @@ if [[ -z "${FLAG_MESSAGING}" ]]; then
     FLAG_MESSAGING=$(prompt_choice "Connect a messaging platform? (Web UI is always available)" msg_opts 3)
 fi
 # Lowercase for consistent matching downstream
-FLAG_MESSAGING="${FLAG_MESSAGING,,}"
+FLAG_MESSAGING=$(to_lower "${FLAG_MESSAGING}")
 export FLAG_MESSAGING
 log_info "Messaging: ${FLAG_MESSAGING}"
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -27,6 +27,9 @@ else
     RESET=$'\033[0m'
 fi
 
+# ── Helpers (Bash 3.2 compatible) ───────────────────────────────────────────
+to_lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
 # ── Logging ─────────────────────────────────────────────────────────────────
 _ts() { date '+%H:%M:%S'; }
 
@@ -69,13 +72,14 @@ _log_to_file() {
 #   result=$(prompt_choice "Pick one:" options 0)
 prompt_choice() {
     local question="$1"
-    local -n _options=$2          # nameref to the array
+    local options_name="$2"       # array name (Bash 3.2 compatible: no nameref)
     local default_idx="${3:-0}"
-    local count=${#_options[@]}
+    local count
+    eval "count=\${#${options_name}[@]}"
 
     # If running in defaults mode, return default immediately
     if [[ "${CLAWSPARK_DEFAULTS}" == "true" ]]; then
-        printf '%s' "${_options[$default_idx]}"
+        eval "printf '%s' \"\${${options_name}[$default_idx]}\""
         return 0
     fi
 
@@ -87,7 +91,9 @@ prompt_choice() {
         if [[ "$i" -eq "$default_idx" ]]; then
             marker=" ${CYAN}(default)${RESET}"
         fi
-        printf '  %s%d)%s %s%s\n' "${GREEN}" $(( i + 1 )) "${RESET}" "${_options[$i]}" "${marker}" >/dev/tty
+        local opt
+        eval "opt=\${${options_name}[$i]}"
+        printf '  %s%d)%s %s%s\n' "${GREEN}" $(( i + 1 )) "${RESET}" "${opt}" "${marker}" >/dev/tty
     done
 
     local selection
@@ -96,12 +102,12 @@ prompt_choice() {
         read -r selection </dev/tty || selection=""
         # Empty input → default
         if [[ -z "${selection}" ]]; then
-            printf '%s' "${_options[$default_idx]}"
+            eval "printf '%s' \"\${${options_name}[$default_idx]}\""
             return 0
         fi
         # Validate numeric input
         if [[ "${selection}" =~ ^[0-9]+$ ]] && (( selection >= 1 && selection <= count )); then
-            printf '%s' "${_options[$(( selection - 1 ))]}"
+            eval "printf '%s' \"\${${options_name}[$(( selection - 1 ))]}\""
             return 0
         fi
         printf '  %sPlease enter a number between 1 and %d%s\n' "${YELLOW}" "${count}" "${RESET}" >/dev/tty
@@ -124,7 +130,7 @@ prompt_yn() {
     printf '\n%s%s %s%s ' "${BOLD}" "${question}" "${hint}" "${RESET}" >/dev/tty
     local answer
     read -r answer </dev/tty || answer=""
-    answer="${answer,,}"  # lowercase
+    answer=$(to_lower "${answer}")
 
     if [[ -z "${answer}" ]]; then
         [[ "${default}" == "y" ]] && return 0 || return 1

--- a/lib/select-model.sh
+++ b/lib/select-model.sh
@@ -186,27 +186,30 @@ _select_model_curated_fallback() {
 }
 
 # ── Shared: present choices and set SELECTED_MODEL_ID/NAME ────────────────
+# Uses array names (Bash 3.2 compatible: no nameref)
 _present_model_choices() {
-    local -n _ids=$1
-    local -n _names=$2
-    local -n _labels=$3
+    local _ids_name="$1"
+    local _names_name="$2"
+    local _labels_name="$3"
     local _default=$4
+    local _labels_len
+    eval "_labels_len=\${#${_labels_name}[@]}"
 
     local choice
-    choice=$(prompt_choice "Which model would you like to run?" _labels "${_default}")
+    choice=$(prompt_choice "Which model would you like to run?" "${_labels_name}" "${_default}")
 
     if [[ "${choice}" == "Let me pick my own model" ]]; then
         if [[ "${CLAWSPARK_DEFAULTS}" == "true" ]]; then
-            SELECTED_MODEL_ID="${_ids[$_default]}"
-            SELECTED_MODEL_NAME="${_names[$_default]}"
+            eval "SELECTED_MODEL_ID=\${${_ids_name}[$_default]}"
+            eval "SELECTED_MODEL_NAME=\${${_names_name}[$_default]}"
         else
             printf '\n  %sEnter the Ollama model ID (e.g. llama3.1:8b):%s ' "${BOLD}" "${RESET}" >/dev/tty
             local custom_id
             read -r custom_id </dev/tty || custom_id=""
             if [[ -z "${custom_id}" ]]; then
                 log_warn "No model entered -- falling back to default."
-                SELECTED_MODEL_ID="${_ids[$_default]}"
-                SELECTED_MODEL_NAME="${_names[$_default]}"
+                eval "SELECTED_MODEL_ID=\${${_ids_name}[$_default]}"
+                eval "SELECTED_MODEL_NAME=\${${_names_name}[$_default]}"
             else
                 SELECTED_MODEL_ID="${custom_id}"
                 SELECTED_MODEL_NAME="${custom_id}"
@@ -214,18 +217,21 @@ _present_model_choices() {
         fi
     else
         local i found=false
-        for i in $(seq 0 $(( ${#_labels[@]} - 2 ))); do
-            if [[ "${_labels[$i]}" == "${choice}" ]]; then
-                SELECTED_MODEL_ID="${_ids[$i]}"
-                SELECTED_MODEL_NAME="${_names[$i]}"
+        local labels_last=$(( _labels_len - 2 ))
+        for i in $(seq 0 "${labels_last}"); do
+            local label_val
+            eval "label_val=\${${_labels_name}[$i]}"
+            if [[ "${label_val}" == "${choice}" ]]; then
+                eval "SELECTED_MODEL_ID=\${${_ids_name}[$i]}"
+                eval "SELECTED_MODEL_NAME=\${${_names_name}[$i]}"
                 found=true
                 break
             fi
         done
         if [[ "${found}" != "true" ]]; then
             log_warn "Could not match selection -- using default model."
-            SELECTED_MODEL_ID="${_ids[$_default]}"
-            SELECTED_MODEL_NAME="${_names[$_default]}"
+            eval "SELECTED_MODEL_ID=\${${_ids_name}[$_default]}"
+            eval "SELECTED_MODEL_NAME=\${${_names_name}[$_default]}"
         fi
     fi
 }

--- a/lib/setup-messaging.sh
+++ b/lib/setup-messaging.sh
@@ -15,7 +15,7 @@ setup_messaging() {
         messaging_choice=$(prompt_choice "Which messaging channel(s) would you like?" options 0)
     fi
 
-    messaging_choice="${messaging_choice,,}"  # lowercase
+    messaging_choice=$(to_lower "${messaging_choice}")
     export MESSAGING_CHOICE="${messaging_choice}"
 
     case "${messaging_choice}" in

--- a/lib/setup-voice.sh
+++ b/lib/setup-voice.sh
@@ -46,7 +46,7 @@ setup_voice() {
 
     # ── Install WhatsApp voice integration if applicable ────────────────────
     local messaging="${FLAG_MESSAGING:-${MESSAGING_CHOICE:-skip}}"
-    messaging="${messaging,,}"  # lowercase
+    messaging=$(to_lower "${messaging}")
     if [[ "${messaging}" == "whatsapp" || "${messaging}" == "both" ]]; then
         local voice_skill_dir="${HOME}/.openclaw/workspace/skills/whatsapp-voice-chat-integration-open-source"
         if [[ -d "${voice_skill_dir}" ]]; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -80,7 +80,7 @@ if command -v ollama &>/dev/null; then
         printf '\n  %sRemove all Ollama models? This frees disk space but re-download needed later.%s\n' "${YELLOW}" "${RESET}"
         printf '  %s[y/N]:%s ' "${BOLD}" "${RESET}"
         read -r remove_models
-        remove_models="${remove_models,,}"
+        remove_models=$(echo "${remove_models}" | tr '[:upper:]' '[:lower:]')
     fi
 
     if [[ "${remove_models}" =~ ^y ]]; then
@@ -136,7 +136,7 @@ if command -v ufw &>/dev/null; then
         printf '\n  %sRevert firewall (UFW) rules added by clawspark?%s\n' "${YELLOW}" "${RESET}"
         printf '  %s[y/N]:%s ' "${BOLD}" "${RESET}"
         read -r revert_fw
-        revert_fw="${revert_fw,,}"
+        revert_fw=$(echo "${revert_fw}" | tr '[:upper:]' '[:lower:]')
     fi
 
     if [[ "${revert_fw}" =~ ^y ]]; then


### PR DESCRIPTION
- Replace local -n (namerefs, Bash 4.3+) with array name + eval in lib/common.sh (prompt_choice) and lib/select-model.sh (_present_model_choices).
- Replace ${var,,} (Bash 4+) with to_lower() using tr in common.sh, install.sh, setup-messaging.sh, setup-voice.sh; use inline tr in uninstall.sh (does not source common.sh).
- Add CHANGES-BASH32-COMPAT.md summarizing changes and portability.

Installation and uninstall now run on macOS default Bash 3.2 and remain portable across Bash 3.2, 4.x, and 5.x.